### PR TITLE
update ltk.cabal also to support parsec3

### DIFF
--- a/ltk.cabal
+++ b/ltk.cabal
@@ -19,7 +19,7 @@ Library
     build-depends: Cabal >=1.6.0 && <1.11, base >=4.0.0.0 && <4.4,
                containers >=0.2 && <0.5, filepath >=1.1.0 && <1.3,
                glib >=0.10.0 && <0.13, gtk >=0.10.0 && <0.13,
-               mtl >=1.1.0.2 && <2.1, parsec >=2.1.0.1 && <2.2,
+               mtl >=1.1.0.2 && <2.1, parsec >=2.1.0.1 && <3.2,
                pretty >=1.0.1.0 && <1.1,
                -- Make sure we get the Cabal compaitble with ghc and haddock
                haddock <2.10, ghc <7.3


### PR DESCRIPTION
Trivial patch which works for me.

I haven't tested similar change on leksah.cabal etc but I think it is also needed.
