### PR TITLE
Bump text, transformers, mtl, Cabal upper bounds

### DIFF
--- a/ltk.cabal
+++ b/ltk.cabal
@@ -24,11 +24,11 @@ Flag gtk3
     default: True
 
 Library
-    build-depends: Cabal >=1.6.0 && <1.19, base >=4.0.0.0 && <4.8,
+    build-depends: Cabal >=1.6.0 && <1.21, base >=4.0.0.0 && <4.8,
                containers >=0.2 && <0.6, filepath >=1.1.0 && <1.4,
-               glib >=0.13.0.0 && <0.14, text >=0.11.0.6 && <1.2,
-               mtl >=1.1.0.2 && <2.2, parsec >=2.1.0.1 && <3.2,
-               pretty >=1.0.1.0 && <1.2, transformers >=0.2.2.0 && <0.4,
+               glib >=0.13.0.0 && <0.14, text >=0.11.0.6 && <1.3,
+               mtl >=1.1.0.2 && <2.3, parsec >=2.1.0.1 && <3.2,
+               pretty >=1.0.1.0 && <1.2, transformers >=0.2.2.0 && <0.5,
                ghc -any
 
     if flag(gtk3)


### PR DESCRIPTION
Increase the upper version bounds of packages to accommodate the most recent versions. This is a part of my effort to get `leksah` to install using the latest libraries.
